### PR TITLE
added repository and description fields

### DIFF
--- a/package.json
+++ b/package.json
@@ -1,7 +1,11 @@
 {
   "name": "cangaroo",
   "version": "1.0.0",
-  "description": "",
+  "description": "Food Bank inventory management system",
+  "repository": {
+    "type": "git",
+    "url": "https://github.com/cwalker226/Cangaroo.git"
+  },
   "main": "server.js",
   "scripts": {
     "test": "npm run lint",


### PR DESCRIPTION
The project's package.json file was missing some fields: Repository and Description.

The lack of a "repository" field was throwing a warning in console - this should hopefully be fixed by adding a link to https://github.com/cwalker226/Cangaroo.git.

Description was blank, is now "Food Bank inventory management system" from the repo description on Github.